### PR TITLE
fix BGG collection auth and parsing

### DIFF
--- a/bot/cogs/BoardGames.py
+++ b/bot/cogs/BoardGames.py
@@ -5,8 +5,6 @@ BoardGames Cog
 Handles board game related commands, including integration with BoardGameGeek (BGG).
 """
 
-import xml.etree.ElementTree as ET
-
 import discord
 from discord.ext import commands
 from utils.discord_context import defer_if_interaction, send_for_context
@@ -187,44 +185,45 @@ class BoardGames(commands.Cog):
         if ctx.interaction and not ctx.interaction.response.is_done():
             await defer_if_interaction(ctx)
 
-        collection_url = f"{self.BASE_URL}collection/{username}?own=1&stats=1"
         self.bot.logger.info(f"Fetching BGG collection for: {username}")
 
         try:
-            async with self.bot.http_session.get(collection_url) as response:
-                if response.status == 200:
-                    xml_data = await response.text()
-                    root = ET.fromstring(xml_data)
-                    games = []
-                    for item in root.findall("item"):
-                        name = item.findtext("name", default="Unknown")
-                        bggid = item.attrib.get("objectid", "N/A")
-                        stats = item.find("stats")
-                        avg_rating_elem = item.find("statistics/ratings/average")
-                        avg_rating = (
-                            avg_rating_elem.attrib.get("value", "N/A")
-                            if avg_rating_elem is not None
-                            else "N/A"
-                        )
-                        min_players = stats.attrib.get("minplayers", "N/A")
-                        max_players = stats.attrib.get("maxplayers", "N/A")
-                        max_playtime = stats.attrib.get("maxplaytime", "N/A")
-                        games.append(
-                            f"{name} (ID: {bggid}, Avg Rating: {avg_rating}, Players: {min_players}-{max_players}, Playtime: {max_playtime} mins)"
-                        )
+            xml_data, status = await bg_utils.fetch_bgg_collection(
+                username,
+                self.bot.logger,
+                self.bot.http_session,
+                cookie_value=self.bot.config.services.bgg_cookie,
+            )
 
-                    await self._send_paginated_embeds(
-                        ctx, games, f"{username}'s BGG Collection", self.bot.embed_color
+            if status == 200 and xml_data:
+                games = bg_utils.parse_bgg_collection(xml_data)
+                formatted_games = []
+                for item in games:
+                    min_players = item.get("minplayers", "N/A")
+                    max_players = item.get("maxplayers", "N/A")
+                    max_playtime = item.get("maxplaytime", "N/A")
+                    formatted_games.append(
+                        f"{item.get('name', 'Unknown')} (ID: {item.get('bggid', 'N/A')}, Avg Rating: {item.get('avgrating', 'N/A')}, Players: {min_players}-{max_players}, Playtime: {max_playtime} mins)"
                     )
-                    self.bot.logger.info(f"Collection fetched for {username}")
-                elif response.status == 202:
-                    await send_for_context(ctx, f"Collection for {username} is being prepared. Try again later.")
-                    self.bot.logger.warning(f"BGG collection preparing for {username}")
-                else:
-                    await send_for_context(ctx, "Failed to fetch collection.")
-                    self.bot.logger.error(
-                        f"Failed fetch for BGG {username}, status: {response.status}"
-                    )
+
+                await self._send_paginated_embeds(
+                    ctx, formatted_games, f"{username}'s BGG Collection", self.bot.embed_color
+                )
+                self.bot.logger.info(f"Collection fetched for {username}")
+            elif status == 202 or status == 429 or status is None:
+                await send_for_context(
+                    ctx, f"Collection for {username} is being prepared. Try again later."
+                )
+                self.bot.logger.warning(f"BGG collection preparing for {username}")
+            elif status in (401, 403):
+                await send_for_context(
+                    ctx,
+                    f"Collection for {username} appears private. Ask the user to make it public or provide a valid BGG session cookie.",
+                )
+                self.bot.logger.warning(f"BGG collection private or unauthorized for {username}")
+            else:
+                await send_for_context(ctx, "Failed to fetch collection.")
+                self.bot.logger.error(f"Failed fetch for BGG {username}, status: {status}")
         except Exception as e:
             self.bot.logger.exception(f"Error fetching BGG collection for {username}: {e}")
             await send_for_context(ctx, "An error occurred during fetch.")

--- a/bot/scripts/backfill_bgg_private.py
+++ b/bot/scripts/backfill_bgg_private.py
@@ -35,7 +35,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 import aiohttp
 import psycopg
 from config.config import Config
-from utils.boardgames import fetch_bgg_collection
+from utils.boardgames import fetch_bgg_collection, set_bgg_private
 
 LOG = logging.getLogger("backfill_bgg_private")
 
@@ -72,30 +72,21 @@ async def _check_user_and_mark(
             )
             return (user_id, bgguser, status, False)
 
-        cur = db_conn.cursor()
         try:
             with suppress(Exception):
                 db_conn.rollback()
 
-            cur.execute(
-                "UPDATE users SET bggprivate = TRUE, datemodified = CURRENT_TIMESTAMP WHERE id = %s RETURNING datemodified;",
-                (user_id,),
-            )
-            updated = cur.fetchone()
-            db_conn.commit()
-            LOG.info(
-                "Marked user id=%s private; datemodified=%s",
-                user_id,
-                updated[0] if updated else None,
-            )
+            if not dry_run:
+                await set_bgg_private(db_conn, LOG, user_id)
+                LOG.info("Marked user id=%s private via helper", user_id)
+            else:
+                LOG.info("[DRY] Would mark user id=%s private via helper", user_id)
             return (user_id, bgguser, status, True)
         except Exception as e:
             LOG.exception("Error marking user id=%s private: %s", user_id, e)
             with suppress(Exception):
                 db_conn.rollback()
             return (user_id, bgguser, status, False)
-        finally:
-            cur.close()
 
     return (user_id, bgguser, status, False)
 

--- a/bot/utils/boardgames.py
+++ b/bot/utils/boardgames.py
@@ -13,6 +13,48 @@ def safe_convert(value, default=0, data_type=int):
         return default
 
 
+def parse_bgg_collection(xml_data: str) -> list[dict[str, object]]:
+    """Parse BGG collection XML into normalized item dictionaries."""
+
+    try:
+        root = ET.fromstring(xml_data)
+    except ET.ParseError:
+        return []
+
+    items: list[dict[str, object]] = []
+    for item in root.findall("item"):
+        status = item.find("status")
+        stats = item.find("stats")
+        rating = stats.find("rating") if stats is not None else None
+
+        items.append(
+            {
+                "name": item.findtext("name", default="Unknown"),
+                "bggid": item.attrib.get("objectid", "N/A"),
+                "avgrating": safe_convert(
+                    rating.findtext("average", default="N/A") if rating is not None else "N/A",
+                    0.0,
+                    float,
+                ),
+                "own": status.get("own", "0") == "1" if status is not None else False,
+                "prevowned": status.get("prevowned", "0") == "1" if status is not None else False,
+                "fortrade": status.get("fortrade", "0") == "1" if status is not None else False,
+                "want": status.get("want", "0") == "1" if status is not None else False,
+                "wanttoplay": status.get("wanttoplay", "0") == "1" if status is not None else False,
+                "wanttobuy": status.get("wanttobuy", "0") == "1" if status is not None else False,
+                "wishlist": status.get("wishlist", "0") == "1" if status is not None else False,
+                "preordered": status.get("preordered", "0") == "1" if status is not None else False,
+                "minplayers": safe_convert(stats.get("minplayers") if stats is not None else None, 0),
+                "maxplayers": safe_convert(stats.get("maxplayers") if stats is not None else None, 0),
+                "minplaytime": safe_convert(stats.get("minplaytime") if stats is not None else None, 0),
+                "maxplaytime": safe_convert(stats.get("maxplaytime") if stats is not None else None, 0),
+                "numplays": safe_convert(item.findtext("numplays", default="0"), 0),
+            }
+        )
+
+    return items
+
+
 async def fetch_bgg_collection(
     username,
     logger,
@@ -36,6 +78,8 @@ async def fetch_bgg_collection(
     url = f"{BASE_URL}collection/{username}?stats=1"
     logger.info("Attempting to fetch BGG collection for user: %s", username)
 
+    last_status = None
+
     for attempt in range(1, max_attempts + 1):
         try:
             headers = {"User-Agent": "DarkBot (https://github.com/benjamind10/darkbot)"}
@@ -51,6 +95,7 @@ async def fetch_bgg_collection(
                     return (await response.text(), 200)
 
                 if status == 202:
+                    last_status = status
                     logger.info(
                         "Collection for %s is queued (202). Attempt %d/%d — retrying after 5s",
                         username,
@@ -61,6 +106,7 @@ async def fetch_bgg_collection(
                     continue
 
                 if status == 429:
+                    last_status = status
                     ra = response.headers.get("Retry-After")
                     delay = float(ra) if ra and ra.isnumeric() else backoff**attempt
                     logger.warning(
@@ -90,6 +136,7 @@ async def fetch_bgg_collection(
                     return (None, status)
 
                 if 500 <= status < 600:
+                    last_status = status
                     delay = backoff**attempt
                     logger.warning(
                         "Server error %s for %s; attempt %d/%d. Retrying after %.1f sec",
@@ -152,7 +199,7 @@ async def fetch_bgg_collection(
         max_attempts,
         username,
     )
-    return (None, None)
+    return (None, last_status)
 
 
 async def upsert_boardgame(db_pool, logger, game_data):
@@ -207,6 +254,23 @@ async def upsert_boardgame(db_pool, logger, game_data):
         raise
 
 
+async def set_bgg_private(db_pool, logger, user_id: int, is_private: bool = True) -> None:
+    try:
+        if hasattr(db_pool, "connection"):
+            async with db_pool.connection() as conn:
+                async with conn.cursor() as cursor:
+                    await cursor.execute("SELECT set_bgg_private(%s, %s);", (user_id, is_private))
+        else:
+            with db_pool.cursor() as cursor:
+                cursor.execute("SELECT set_bgg_private(%s, %s);", (user_id, is_private))
+            if hasattr(db_pool, "commit"):
+                db_pool.commit()
+        logger.info("Marked user id=%s bggprivate=%s via SQL helper", user_id, is_private)
+    except Exception as e:
+        logger.exception(f"Exception occurred while marking user {user_id} private: {e}")
+        raise
+
+
 async def process_bgg_users(
     db_pool, session: aiohttp.ClientSession, logger, cookie_value: str | None = None
 ):
@@ -214,7 +278,7 @@ async def process_bgg_users(
         async with db_pool.connection() as conn:
             async with conn.cursor() as cursor:
                 logger.debug("Fetching users.")
-                await cursor.execute("SELECT id, bgguser FROM users WHERE bgguser IS NOT NULL;")
+                await cursor.execute("SELECT id, bgguser FROM get_all_bggusers();")
                 users = await cursor.fetchall()
                 logger.debug(f"Fetched {len(users)} users.")
 
@@ -228,22 +292,10 @@ async def process_bgg_users(
                 if status in (401, 403):
                     try:
                         logger.info("Marking user id=%s as having a private BGG account", user_id)
-                        async with db_pool.connection() as conn:
-                            async with conn.cursor() as cur:
-                                await cur.execute(
-                                    "UPDATE users SET bggprivate = TRUE, datemodified = CURRENT_TIMESTAMP WHERE id = %s RETURNING datemodified;",
-                                    (user_id,),
-                                )
-                                updated = await cur.fetchone()
-                                if updated:
-                                    logger.info(
-                                        "Marked user id=%s private; datemodified=%s",
-                                        user_id,
-                                        updated[0],
-                                    )
+                        await set_bgg_private(db_pool, logger, user_id)
                     except Exception as mark_exc:
                         logger.warning(
-                            "Could not mark user %s as private in DB (maybe migration missing): %s",
+                            "Could not mark user %s as private via helper (maybe migration missing): %s",
                             user_id,
                             mark_exc,
                         )
@@ -256,40 +308,17 @@ async def process_bgg_users(
                     logger.warning("No data returned for user %s — skipping", bgguser)
                     continue
 
-                try:
-                    root = ET.fromstring(xml_data)
-                except ET.ParseError:
-                    logger.exception(
-                        "Failed to parse XML for %s — first 500 chars: %s",
+                games = parse_bgg_collection(xml_data)
+                if not games:
+                    logger.warning(
+                        "No parsable collection items for user %s; first 500 chars: %s",
                         bgguser,
                         (xml_data or "")[:500],
                     )
                     continue
 
-                for item in root.findall("item"):
-                    item_status = item.find("status")
-                    game_data = {
-                        "userid": user_id,
-                        "name": (
-                            item.find("name").text if item.find("name") is not None else "Unknown"
-                        ),
-                        "bggid": safe_convert(item.get("objectid"), 0),
-                        "avgrating": safe_convert(
-                            item.find("stats/rating/average").get("value"), 0.0, float
-                        ),
-                        "own": item_status.get("own", "0") == "1",
-                        "prevowned": item_status.get("prevowned", "0") == "1",
-                        "fortrade": item_status.get("fortrade", "0") == "1",
-                        "want": item_status.get("want", "0") == "1",
-                        "wanttoplay": item_status.get("wanttoplay", "0") == "1",
-                        "wanttobuy": item_status.get("wanttobuy", "0") == "1",
-                        "wishlist": item_status.get("wishlist", "0") == "1",
-                        "preordered": item_status.get("preordered", "0") == "1",
-                        "minplayers": safe_convert(item.find("stats").get("minplayers"), 0),
-                        "maxplayers": safe_convert(item.find("stats").get("maxplayers"), 0),
-                        "minplaytime": safe_convert(item.find("stats").get("minplaytime"), 0),
-                        "numplays": safe_convert(item.find("numplays").text, 0),
-                    }
+                for parsed_item in games:
+                    game_data = {"userid": user_id, **parsed_item}
 
                     try:
                         await upsert_boardgame(db_pool, logger, game_data)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,7 +48,8 @@ Copy `bot/.env.example` to `bot/.env` and fill in your values.
 | `WEATHER_API_KEY` | Weather command |
 | `API_COINCAP` | Cryptocurrency commands |
 | `IP_INFO` | IP lookup command |
-| `BGG_COOKIE` | BoardGameGeek private collections |
+| `BGG_AUTH_COOKIE` | BoardGameGeek private collections (preferred) |
+| `BGG_COOKIE` | BoardGameGeek private collections (legacy alias) |
 | `YOUTUBE_API_KEY` | YouTube API |
 
 ### Development

--- a/tests/test_boardgames.py
+++ b/tests/test_boardgames.py
@@ -1,8 +1,45 @@
 import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
+import aiohttp
 
-from bot.utils.boardgames import BASE_URL, fetch_bgg_collection
+from bot.utils.boardgames import (
+    BASE_URL,
+    fetch_bgg_collection,
+    parse_bgg_collection,
+    process_bgg_users,
+    set_bgg_private,
+)
+
+
+@pytest.mark.asyncio
+async def test_fetch_bgg_collection_sends_cookie_header(mock_http_session):
+    username = "DadDialTone"
+    url = f"{BASE_URL}collection/{username}?stats=1"
+    seen_headers = {}
+
+    def _callback(url_obj, **kwargs):
+        seen_headers.update(kwargs.get("headers", {}))
+        return {
+            "status": 200,
+            "body": "<items></items>",
+        }
+
+    mock_http_session.mocked.get(url, callback=_callback)
+
+    res, status = await fetch_bgg_collection(
+        username,
+        logging.getLogger("test"),
+        mock_http_session.session,
+        cookie_value="bb=session-token; foo=bar",
+        max_attempts=1,
+    )
+
+    assert status == 200
+    assert res == "<items></items>"
+    assert seen_headers.get("Cookie") == "bb=session-token; foo=bar"
 
 
 @pytest.mark.asyncio
@@ -13,8 +50,281 @@ async def test_fetch_bgg_collection_401_logs_and_returns_none(caplog, mock_http_
 
     mock_http_session.mocked.get(url, status=401, body=b"Unauthorized")
     res, status = await fetch_bgg_collection(
-        username, logging.getLogger("test"), mock_http_session.session, max_attempts=1
+        username, logging.getLogger("test"), mock_http_session.session, max_attempts=3
     )
 
     assert res is None and status == 401
     assert any("Authorization error fetching BGG" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_fetch_bgg_collection_202_returns_last_status(mock_http_session, monkeypatch):
+    username = "QueuedUser"
+    url = f"{BASE_URL}collection/{username}?stats=1"
+
+    mock_http_session.mocked.get(url, status=202, body=b"Queued")
+    sleep = AsyncMock()
+    monkeypatch.setattr("bot.utils.boardgames.asyncio.sleep", sleep)
+
+    res, status = await fetch_bgg_collection(
+        username,
+        logging.getLogger("test"),
+        mock_http_session.session,
+        max_attempts=1,
+    )
+
+    assert res is None and status == 202
+    sleep.assert_awaited_once_with(5)
+
+
+@pytest.mark.asyncio
+async def test_fetch_bgg_collection_429_respects_retry_after(mock_http_session, monkeypatch):
+    username = "RateLimitedUser"
+    url = f"{BASE_URL}collection/{username}?stats=1"
+
+    mock_http_session.mocked.get(
+        url, status=429, body=b"Too Many Requests", headers={"Retry-After": "7"}
+    )
+    sleep = AsyncMock()
+    monkeypatch.setattr("bot.utils.boardgames.asyncio.sleep", sleep)
+
+    res, status = await fetch_bgg_collection(
+        username,
+        logging.getLogger("test"),
+        mock_http_session.session,
+        max_attempts=1,
+    )
+
+    assert res is None and status == 429
+    sleep.assert_awaited_once_with(7.0)
+
+
+@pytest.mark.asyncio
+async def test_fetch_bgg_collection_5xx_returns_last_status(mock_http_session, monkeypatch):
+    username = "ServerErrorUser"
+    url = f"{BASE_URL}collection/{username}?stats=1"
+
+    mock_http_session.mocked.get(url, status=503, body=b"Unavailable")
+    sleep = AsyncMock()
+    monkeypatch.setattr("bot.utils.boardgames.asyncio.sleep", sleep)
+
+    res, status = await fetch_bgg_collection(
+        username,
+        logging.getLogger("test"),
+        mock_http_session.session,
+        max_attempts=1,
+    )
+
+    assert res is None and status == 503
+    sleep.assert_awaited_once_with(2.0)
+
+
+@pytest.mark.asyncio
+async def test_fetch_bgg_collection_client_error_returns_last_status(mock_http_session, monkeypatch):
+    username = "ClientErrorUser"
+    url = f"{BASE_URL}collection/{username}?stats=1"
+
+    mock_http_session.mocked.get(url, exception=aiohttp.ClientError("boom"))
+    sleep = AsyncMock()
+    monkeypatch.setattr("bot.utils.boardgames.asyncio.sleep", sleep)
+
+    res, status = await fetch_bgg_collection(
+        username,
+        logging.getLogger("test"),
+        mock_http_session.session,
+        max_attempts=1,
+    )
+
+    assert res is None and status is None
+    sleep.assert_awaited_once_with(2.0)
+
+
+@pytest.mark.asyncio
+async def test_fetch_bgg_collection_unexpected_status_returns_status(mock_http_session):
+    username = "UnexpectedUser"
+    url = f"{BASE_URL}collection/{username}?stats=1"
+
+    mock_http_session.mocked.get(url, status=418, body=b"Teapot")
+
+    res, status = await fetch_bgg_collection(
+        username,
+        logging.getLogger("test"),
+        mock_http_session.session,
+        max_attempts=3,
+    )
+
+    assert res is None and status == 418
+
+
+def test_parse_bgg_collection_normal_item():
+    xml_data = """
+    <items>
+      <item objectid="123">
+        <name>Terraforming Mars</name>
+        <status own="1" prevowned="0" fortrade="0" want="0" wanttoplay="1" wanttobuy="0" wishlist="0" preordered="0" />
+        <stats minplayers="1" maxplayers="5" minplaytime="120" maxplaytime="120">
+          <rating><average value="8.42" /></rating>
+        </stats>
+        <numplays>17</numplays>
+      </item>
+    </items>
+    """
+
+    items = parse_bgg_collection(xml_data)
+
+    assert items == [
+        {
+            "name": "Terraforming Mars",
+            "bggid": "123",
+            "avgrating": 8.42,
+            "own": True,
+            "prevowned": False,
+            "fortrade": False,
+            "want": False,
+            "wanttoplay": True,
+            "wanttobuy": False,
+            "wishlist": False,
+            "preordered": False,
+            "minplayers": 1,
+            "maxplayers": 5,
+            "minplaytime": 120,
+            "maxplaytime": 120,
+            "numplays": 17,
+        }
+    ]
+
+
+def test_parse_bgg_collection_missing_optional_fields():
+    xml_data = """
+    <items>
+      <item objectid="456">
+        <name>Unknown Horizons</name>
+      </item>
+    </items>
+    """
+
+    items = parse_bgg_collection(xml_data)
+
+    assert items == [
+        {
+            "name": "Unknown Horizons",
+            "bggid": "456",
+            "avgrating": 0.0,
+            "own": False,
+            "prevowned": False,
+            "fortrade": False,
+            "want": False,
+            "wanttoplay": False,
+            "wanttobuy": False,
+            "wishlist": False,
+            "preordered": False,
+            "minplayers": 0,
+            "maxplayers": 0,
+            "minplaytime": 0,
+            "maxplaytime": 0,
+            "numplays": 0,
+        }
+    ]
+
+
+def test_parse_bgg_collection_malformed_xml():
+    assert parse_bgg_collection("<items><item></items>") == []
+
+
+@pytest.mark.asyncio
+async def test_bgg_collection_command_private_message(bot, mock_http_session, monkeypatch):
+    from bot.cogs.BoardGames import BoardGames
+
+    cog = BoardGames(bot)
+    ctx = SimpleNamespace(interaction=None, send=AsyncMock())
+    bot.logger = logging.getLogger("test")
+
+    monkeypatch.setattr(
+        "bot.cogs.BoardGames.bg_utils.fetch_bgg_collection",
+        AsyncMock(return_value=(None, 403)),
+    )
+    send = AsyncMock()
+    monkeypatch.setattr("bot.cogs.BoardGames.send_for_context", send)
+
+    await cog.bgg_collection(ctx, "PrivateUser")
+
+    send.assert_awaited_once()
+    assert "appears private" in send.await_args.args[1]
+
+
+@pytest.mark.asyncio
+async def test_bgg_collection_command_queued_message(bot, monkeypatch):
+    from bot.cogs.BoardGames import BoardGames
+
+    cog = BoardGames(bot)
+    ctx = SimpleNamespace(interaction=None, send=AsyncMock())
+    bot.logger = logging.getLogger("test")
+
+    monkeypatch.setattr(
+        "bot.cogs.BoardGames.bg_utils.fetch_bgg_collection",
+        AsyncMock(return_value=(None, 202)),
+    )
+    send = AsyncMock()
+    monkeypatch.setattr("bot.cogs.BoardGames.send_for_context", send)
+
+    await cog.bgg_collection(ctx, "QueuedUser")
+
+    send.assert_awaited_once()
+    assert "being prepared" in send.await_args.args[1]
+
+
+@pytest.mark.asyncio
+async def test_bgg_collection_command_malformed_response_message(bot, monkeypatch):
+    from bot.cogs.BoardGames import BoardGames
+
+    cog = BoardGames(bot)
+    ctx = SimpleNamespace(interaction=None, send=AsyncMock())
+    bot.logger = logging.getLogger("test")
+
+    monkeypatch.setattr(
+        "bot.cogs.BoardGames.bg_utils.fetch_bgg_collection",
+        AsyncMock(return_value=(None, 500)),
+    )
+    send = AsyncMock()
+    monkeypatch.setattr("bot.cogs.BoardGames.send_for_context", send)
+
+    await cog.bgg_collection(ctx, "BrokenUser")
+
+    send.assert_awaited_once_with(ctx, "Failed to fetch collection.")
+
+
+@pytest.mark.asyncio
+async def test_set_bgg_private_calls_sql_helper(mock_db_pool):
+    await set_bgg_private(mock_db_pool, logging.getLogger("test"), 42)
+
+    mock_db_pool.connection.assert_called_once()
+    mock_db_pool.connection_obj.cursor.assert_called_once()
+    mock_db_pool.connection_obj.commit.assert_not_called()
+    mock_db_pool.connection_obj.cursor.return_value.__aenter__.return_value.execute.assert_awaited_once_with(
+        "SELECT set_bgg_private(%s, %s);",
+        (42, True),
+    )
+
+
+@pytest.mark.asyncio
+async def test_process_bgg_users_marks_private_accounts_via_helper(mock_db_pool, mock_http_session, monkeypatch):
+    username = "PrivateUser"
+    url = f"{BASE_URL}collection/{username}?stats=1"
+
+    mock_http_session.mocked.get(url, status=401, body=b"Unauthorized")
+    connection_cursor = mock_db_pool.connection_obj.cursor.return_value.__aenter__.return_value
+    connection_cursor.fetchall.return_value = [(7, username)]
+
+    called = []
+
+    async def _fake_set_bgg_private(db_pool, logger, user_id, is_private=True):
+        called.append((db_pool, user_id, is_private))
+
+    monkeypatch.setattr("bot.utils.boardgames.set_bgg_private", _fake_set_bgg_private)
+
+    await process_bgg_users(mock_db_pool, mock_http_session.session, logging.getLogger("test"))
+
+    assert called == [(mock_db_pool, 7, True)]
+    connection_cursor.execute.assert_any_await("SELECT id, bgguser FROM get_all_bggusers();")
+    connection_cursor.fetchall.assert_awaited_once()
+    assert connection_cursor.execute.await_count == 1


### PR DESCRIPTION
## Summary
- Route live BGG collection display through the shared authenticated fetch helper so private collections use the configured cookie and return clearer status-specific messages.
- Centralize collection XML parsing and private-account marking so sync, display, and backfill paths share the same safety and SQL helper behavior.
- Expand regression coverage for auth failures, queued/rate-limited responses, malformed XML, and private-account sync flows.

## Testing
- `python -m compileall bot tests`
- `pytest tests/test_boardgames.py` *(not available in this environment; pytest is not installed)*
- `pyright` *(not available in this environment; pyright is not installed)*