### PR TITLE
Fix BGG private flag updates

### DIFF
--- a/bot/utils/boardgames.py
+++ b/bot/utils/boardgames.py
@@ -4,6 +4,11 @@ import xml.etree.ElementTree as ET
 import aiohttp
 
 BASE_URL = "https://api.geekdo.com/xmlapi/"
+SET_BGG_PRIVATE_SQL = """
+UPDATE users
+SET bggprivate = %s::boolean, datemodified = CURRENT_TIMESTAMP
+WHERE id = %s::integer;
+"""
 
 
 def safe_convert(value, default=0, data_type=int):
@@ -259,13 +264,13 @@ async def set_bgg_private(db_pool, logger, user_id: int, is_private: bool = True
         if hasattr(db_pool, "connection"):
             async with db_pool.connection() as conn:
                 async with conn.cursor() as cursor:
-                    await cursor.execute("SELECT set_bgg_private(%s, %s);", (user_id, is_private))
+                    await cursor.execute(SET_BGG_PRIVATE_SQL, (is_private, user_id))
         else:
             with db_pool.cursor() as cursor:
-                cursor.execute("SELECT set_bgg_private(%s, %s);", (user_id, is_private))
+                cursor.execute(SET_BGG_PRIVATE_SQL, (is_private, user_id))
             if hasattr(db_pool, "commit"):
                 db_pool.commit()
-        logger.info("Marked user id=%s bggprivate=%s via SQL helper", user_id, is_private)
+        logger.info("Marked user id=%s bggprivate=%s", user_id, is_private)
     except Exception as e:
         logger.exception(f"Exception occurred while marking user {user_id} private: {e}")
         raise

--- a/tests/test_boardgames.py
+++ b/tests/test_boardgames.py
@@ -7,6 +7,7 @@ import aiohttp
 
 from bot.utils.boardgames import (
     BASE_URL,
+    SET_BGG_PRIVATE_SQL,
     fetch_bgg_collection,
     parse_bgg_collection,
     process_bgg_users,
@@ -294,15 +295,15 @@ async def test_bgg_collection_command_malformed_response_message(bot, monkeypatc
 
 
 @pytest.mark.asyncio
-async def test_set_bgg_private_calls_sql_helper(mock_db_pool):
+async def test_set_bgg_private_updates_user_flag(mock_db_pool):
     await set_bgg_private(mock_db_pool, logging.getLogger("test"), 42)
 
     mock_db_pool.connection.assert_called_once()
     mock_db_pool.connection_obj.cursor.assert_called_once()
     mock_db_pool.connection_obj.commit.assert_not_called()
     mock_db_pool.connection_obj.cursor.return_value.__aenter__.return_value.execute.assert_awaited_once_with(
-        "SELECT set_bgg_private(%s, %s);",
-        (42, True),
+        SET_BGG_PRIVATE_SQL,
+        (True, 42),
     )
 
 


### PR DESCRIPTION
## Header Links

[Task Ticket](https://cloud.humanlayer.com/artifacts/019ee2a6-c4f5-7c99-9336-9392d627cad5) | [Research](https://cloud.humanlayer.com/artifacts/019ee2ac-61c5-7ec4-9026-6f764aaf6602) | [Structure Outline](https://cloud.humanlayer.com/artifacts/019ee2b4-3d4b-7bdb-993c-e040d193a308) | [PR Walkthrough (alpha)](https://cloud.humanlayer.com/artifacts/019ee2e7-0059-77f0-855d-d18f9308f16e)

## What problems was I solving

The merged BGG collection auth work correctly identified private or unauthorized BoardGameGeek collections, but a production deployment surfaced a follow-up database failure: marking those users private called `SELECT set_bgg_private(%s, %s);`, and PostgreSQL reported `function set_bgg_private(smallint, boolean) does not exist`.

This PR makes the private-account marker resilient by updating `users.bggprivate` directly with explicit casts. After this ships, 401/403 BGG users can be marked private and skipped on subsequent syncs even if the optional SQL helper function is missing or PostgreSQL infers a narrower integer parameter type.

## What user-facing changes did I ship

- [bot/utils/boardgames.py](https://github.com/benjamind10/darkbot/pull/26/files#diff-082a0993bdeb33aa09287b38048d24ddda7a79f13bc643c50f13a1246b60eaf5) - Private BGG users are marked with a direct `UPDATE users` statement instead of a helper function call that can be absent or fail signature resolution.
- [tests/test_boardgames.py](https://github.com/benjamind10/darkbot/pull/26/files#diff-96b0034817cd4b7c68ce02faa3d1b2c3a0f7d310111ccf1c28097524486fe165) - The regression expectation now verifies the direct update SQL and parameter ordering.

## How I implemented it

### Backend Changes

- [bot/utils/boardgames.py](https://github.com/benjamind10/darkbot/pull/26/files#diff-082a0993bdeb33aa09287b38048d24ddda7a79f13bc643c50f13a1246b60eaf5R7) - Added `SET_BGG_PRIVATE_SQL`, which mirrors the helper function's behavior by setting `bggprivate` and refreshing `datemodified`.
- [bot/utils/boardgames.py](https://github.com/benjamind10/darkbot/pull/26/files#diff-082a0993bdeb33aa09287b38048d24ddda7a79f13bc643c50f13a1246b60eaf5R267) - Replaced both async-pool and direct-connection helper calls with the shared direct update statement.
- [bot/utils/boardgames.py](https://github.com/benjamind10/darkbot/pull/26/files#diff-082a0993bdeb33aa09287b38048d24ddda7a79f13bc643c50f13a1246b60eaf5R273) - Adjusted the success log message so it no longer claims the SQL helper was used.

### Test Changes

- [tests/test_boardgames.py](https://github.com/benjamind10/darkbot/pull/26/files#diff-96b0034817cd4b7c68ce02faa3d1b2c3a0f7d310111ccf1c28097524486fe165R10) - Imported the SQL constant so the test follows the production statement.
- [tests/test_boardgames.py](https://github.com/benjamind10/darkbot/pull/26/files#diff-96b0034817cd4b7c68ce02faa3d1b2c3a0f7d310111ccf1c28097524486fe165R300) - Renamed the test to describe private flag updates rather than helper calls and asserted `(True, 42)` parameter order.

## Deviations from the plan

No dedicated `*plan*.md` file exists in the task directory.

### Implemented as planned

- The broader task goal remains intact: private BGG accounts should be marked consistently so repeated sync attempts skip them.
- The test suite still covers the private marker path through the repository's existing async DB pool mocking pattern.

### Deviations/surprises

- The structure outline originally proposed routing private marking through the schema's `set_bgg_private()` helper. Production logs showed that relying on that helper can fail when the migration/function is missing or when PostgreSQL resolves the bound user id as `smallint`, so this follow-up intentionally uses a direct `UPDATE` with explicit casts instead.

### Additions not in plan

- Added a Python-level `SET_BGG_PRIVATE_SQL` constant to keep the direct update statement shared between connection styles and test assertions.

### Items planned but not implemented

- No database migration is included. The code no longer requires the helper function to exist for this path, so a migration is unnecessary for the reported failure.

## How to verify it

### Manual Testing

- [ ] Check out the branch: `git checkout fix-board-game-geek-api-authentication-and-collection-fetching`
- [ ] Pull the latest commit: `git pull origin fix-board-game-geek-api-authentication-and-collection-fetching`
- [ ] Rebuild only the bot container: `docker compose up -d --no-deps --build python-app`
- [ ] Confirm the deployed container no longer contains the old helper call:

```bash
docker compose exec -T python-app python - <<'PY'
from pathlib import Path
text = Path("/usr/local/share/bot/utils/boardgames.py").read_text()
print("uses old helper:", "SELECT set_bgg_private" in text)
print("uses direct update:", "UPDATE users" in text and "bggprivate" in text)
PY
```

Expected output:

```text
uses old helper: False
uses direct update: True
```

- [ ] Run the manual BGG update and confirm private/unauthorized users no longer log `function set_bgg_private(smallint, boolean) does not exist`.

### Automated Tests

```bash
pytest tests/test_boardgames.py
pyright
```

Note: automated tests were not run in this environment because `pytest` is not installed.

## Description for the changelog

Fix BGG private-account marking so sync no longer depends on the optional `set_bgg_private()` database helper.
