### PR TITLE
fix: keep Spotify search command registered

### DIFF
--- a/bot/cogs/Spotify.py
+++ b/bot/cogs/Spotify.py
@@ -188,6 +188,13 @@ class Spotify(commands.Cog):
         if ctx.interaction and not ctx.interaction.response.is_done():
             await defer_if_interaction(ctx)
 
+        if not self.bot.config.music.enabled or not self.bot.config.lavalink.enabled:
+            await send_for_context(
+                ctx,
+                "Spotify playback is disabled because music/Lavalink is not enabled.",
+            )
+            return
+
         token = await self._get_token(ctx)
         if not token:
             return
@@ -264,7 +271,4 @@ class Spotify(commands.Cog):
 
 async def setup(bot):
     """Load the Spotify cog."""
-    if not bot.config.music.enabled or not bot.config.lavalink.enabled:
-        bot.logger.info("Spotify | Skipping cog load because music is disabled in config")
-        return
     await bot.add_cog(Spotify(bot))

--- a/tests/test_spotify.py
+++ b/tests/test_spotify.py
@@ -1,0 +1,51 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from bot.cogs import Spotify as spotify_module
+
+
+@pytest.mark.asyncio
+async def test_setup_adds_spotify_cog_even_when_music_disabled():
+    bot = SimpleNamespace(
+        config=SimpleNamespace(
+            music=SimpleNamespace(enabled=False),
+            lavalink=SimpleNamespace(enabled=False),
+        ),
+        add_cog=AsyncMock(),
+        logger=SimpleNamespace(info=AsyncMock()),
+    )
+
+    await spotify_module.setup(bot)
+
+    bot.add_cog.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_spplay_exits_early_when_music_disabled(monkeypatch):
+    bot = SimpleNamespace(
+        config=SimpleNamespace(
+            music=SimpleNamespace(enabled=False),
+            lavalink=SimpleNamespace(enabled=False),
+            services=SimpleNamespace(spotify_client_id="id", spotify_client_secret="secret"),
+        ),
+        logger=SimpleNamespace(info=AsyncMock(), error=AsyncMock()),
+        redis_manager=SimpleNamespace(),
+        http_session=SimpleNamespace(get=AsyncMock()),
+    )
+    cog = spotify_module.Spotify(bot)
+    ctx = SimpleNamespace(interaction=None)
+    send = AsyncMock()
+    get_token = AsyncMock()
+
+    monkeypatch.setattr(spotify_module, "send_for_context", send)
+    monkeypatch.setattr(cog, "_get_token", get_token)
+
+    await cog.spplay(ctx, query="test track")
+
+    send.assert_awaited_once_with(
+        ctx, "Spotify playback is disabled because music/Lavalink is not enabled."
+    )
+    get_token.assert_not_awaited()
+    bot.http_session.get.assert_not_awaited()


### PR DESCRIPTION
## Summary
- Always register the Spotify cog so `/spsearch` is synced even when music/Lavalink is disabled.
- Add a runtime guard so `/spplay` returns a clear disabled message instead of failing at command lookup time.
- Cover the registration and guard behavior with focused tests.

## Verification
- `python -m compileall bot/cogs/Spotify.py tests/test_spotify.py tests/test_bot_startup.py`
- Tested successfully on the droplet after pulling this branch