### PR TITLE
Fix BGG API authentication requests

### DIFF
--- a/bot/cogs/BoardGames.py
+++ b/bot/cogs/BoardGames.py
@@ -12,7 +12,7 @@ from bot.utils import boardgames as bg_utils
 
 
 class BoardGames(commands.Cog):
-    API2_BASE_URL = "https://api.geekdo.com/xmlapi2/"
+    API2_BASE_URL = bg_utils.API2_BASE_URL
 
     def __init__(self, bot):
         self.bot = bot
@@ -76,7 +76,13 @@ class BoardGames(commands.Cog):
         search_url = f"{self.API2_BASE_URL}search"
         self.bot.logger.info(f"BGG search query: {search_query}")
 
-        async with self.bot.http_session.get(search_url, params={"query": search_query}) as response:
+        headers = {"User-Agent": bg_utils.BGG_USER_AGENT}
+
+        async with self.bot.http_session.get(
+            search_url,
+            headers=headers,
+            params={"query": search_query},
+        ) as response:
             if response.status == 200:
                 xml_data = await response.text()
                 games = bg_utils.parse_bgg_search(xml_data)[:5]
@@ -118,7 +124,13 @@ class BoardGames(commands.Cog):
         self.bot.logger.info(f"Fetching BGG info for ID: {game_id}")
         info_url = f"{self.API2_BASE_URL}thing"
 
-        async with self.bot.http_session.get(info_url, params={"id": game_id, "stats": 1}) as response:
+        headers = {"User-Agent": bg_utils.BGG_USER_AGENT}
+
+        async with self.bot.http_session.get(
+            info_url,
+            headers=headers,
+            params={"id": game_id, "stats": 1},
+        ) as response:
             if response.status == 200:
                 xml_data = await response.text()
                 game = bg_utils.parse_bgg_thing(xml_data)

--- a/bot/utils/boardgames.py
+++ b/bot/utils/boardgames.py
@@ -3,8 +3,9 @@ import xml.etree.ElementTree as ET
 
 import aiohttp
 
-BASE_URL = "https://api.geekdo.com/xmlapi/"
-API2_BASE_URL = "https://api.geekdo.com/xmlapi2/"
+BASE_URL = "https://boardgamegeek.com/xmlapi/"
+API2_BASE_URL = "https://boardgamegeek.com/xmlapi2/"
+BGG_USER_AGENT = "DarkBot (https://github.com/benjamind10/darkbot)"
 SET_BGG_PRIVATE_SQL = """
 UPDATE users
 SET bggprivate = %s::boolean, datemodified = CURRENT_TIMESTAMP
@@ -181,7 +182,7 @@ async def fetch_bgg_collection(
 
     for attempt in range(1, max_attempts + 1):
         try:
-            headers = {"User-Agent": "DarkBot (https://github.com/benjamind10/darkbot)"}
+            headers = {"User-Agent": BGG_USER_AGENT}
 
             params = {"username": username, "stats": 1, "subtype": "boardgame"}
 

--- a/tests/test_boardgames.py
+++ b/tests/test_boardgames.py
@@ -10,6 +10,7 @@ from aioresponses import CallbackResult
 from bot.utils.boardgames import (
     BASE_URL,
     API2_BASE_URL,
+    BGG_USER_AGENT,
     SET_BGG_PRIVATE_SQL,
     fetch_bgg_collection,
     parse_bgg_search,
@@ -45,6 +46,7 @@ async def test_fetch_bgg_collection_sends_cookie_header(mock_http_session):
     assert status == 200
     assert res == "<items></items>"
     assert seen_headers.get("Cookie") == "bb=session-token; foo=bar"
+    assert seen_headers.get("User-Agent") == BGG_USER_AGENT
     assert seen_params == {"username": username, "stats": 1, "subtype": "boardgame", "showprivate": 1}
 
 
@@ -331,9 +333,11 @@ async def test_search_boardgame_uses_api2_search(bot, mock_http_session, monkeyp
     bot.config = SimpleNamespace(services=SimpleNamespace(bgg_cookie=None))
 
     seen_params = {}
+    seen_headers = {}
 
     def _callback(url_obj, **kwargs):
         seen_params.update(kwargs.get("params", {}))
+        seen_headers.update(kwargs.get("headers", {}))
         return CallbackResult(
             status=200,
             body="""
@@ -353,6 +357,7 @@ async def test_search_boardgame_uses_api2_search(bot, mock_http_session, monkeyp
     await cog.search_boardgame.callback(cog, ctx, search_query="Catan")
 
     assert seen_params == {"query": "Catan"}
+    assert seen_headers.get("User-Agent") == BGG_USER_AGENT
     embed = send.await_args.kwargs["embed"]
     assert embed.title == "Top 5 search results for 'Catan'"
     assert embed.fields[0].name == "Catan (1995)"
@@ -369,9 +374,11 @@ async def test_boardgame_info_uses_api2_thing(bot, mock_http_session, monkeypatc
     bot.config = SimpleNamespace(services=SimpleNamespace(bgg_cookie=None))
 
     seen_params = {}
+    seen_headers = {}
 
     def _callback(url_obj, **kwargs):
         seen_params.update(kwargs.get("params", {}))
+        seen_headers.update(kwargs.get("headers", {}))
         return CallbackResult(
             status=200,
             body="""
@@ -403,6 +410,7 @@ async def test_boardgame_info_uses_api2_thing(bot, mock_http_session, monkeypatc
     await cog.boardgame_info.callback(cog, ctx, "13")
 
     assert seen_params == {"id": "13", "stats": 1}
+    assert seen_headers.get("User-Agent") == BGG_USER_AGENT
     embed = send.await_args.kwargs["embed"]
     assert embed.title == "**Catan**"
     assert "**Published:** 1995" in embed.description


### PR DESCRIPTION
## Header Links

[Fix BGG Search API Authentication Error](https://cloud.humanlayer.com/artifacts/019eec60-7755-716b-925f-a0621a8743b7) | [Artifacts](https://cloud.humanlayer.com/artifacts/019eec60-7755-716b-925f-a0621a8743b7) | [PR Walkthrough (alpha)](https://cloud.humanlayer.com/artifacts/019eec64-e9ce-7b00-8b6c-20a30b986bab)

## What problems was I solving

The `bgsearch` command was reaching BoardGameGeek but receiving `401 Unauthorized`, so users could not search for games even though the XML parsing and Discord embed flow were otherwise healthy. This PR updates the BGG request contract so public search and game info calls use BoardGameGeek's canonical XML endpoints and identify DarkBot with the same explicit User-Agent already used by collection fetches.

Success means `bgsearch` and `bginfo` issue authenticated-enough public requests to BGG without changing command UX, parsing behavior, or private collection cookie handling.

## What user-facing changes did I ship

- [bot/cogs/BoardGames.py](https://github.com/benjamind10/darkbot/pull/30/files#diff-65329b5bb047d9bd9557a61f55e010b1228914453b12779433548ce81248ad4d) - `bgsearch` and `bginfo` now send a DarkBot User-Agent with their BGG XML API2 requests.
- [bot/utils/boardgames.py](https://github.com/benjamind10/darkbot/pull/30/files#diff-082a0993bdeb33aa09287b38048d24ddda7a79f13bc643c50f13a1246b60eaf5) - BGG endpoints now point at `boardgamegeek.com` and the User-Agent is centralized for all BGG HTTP callers.
- [tests/test_boardgames.py](https://github.com/benjamind10/darkbot/pull/30/files#diff-96b0034817cd4b7c68ce02faa3d1b2c3a0f7d310111ccf1c28097524486fe165) - Request-shape tests now assert that collection, search, and thing calls include the expected User-Agent.

## How I implemented it

### Backend Changes

- [bot/utils/boardgames.py](https://github.com/benjamind10/darkbot/pull/30/files#diff-082a0993bdeb33aa09287b38048d24ddda7a79f13bc643c50f13a1246b60eaf5R6) - Switched both BGG XML constants from `api.geekdo.com` to `boardgamegeek.com`, matching the currently supported public XML endpoints.
- [bot/utils/boardgames.py](https://github.com/benjamind10/darkbot/pull/30/files#diff-082a0993bdeb33aa09287b38048d24ddda7a79f13bc643c50f13a1246b60eaf5R8) - Added `BGG_USER_AGENT` so the bot's BGG identity is shared instead of repeated inline.
- [bot/utils/boardgames.py](https://github.com/benjamind10/darkbot/pull/30/files#diff-082a0993bdeb33aa09287b38048d24ddda7a79f13bc643c50f13a1246b60eaf5R185) - Updated collection fetching to reuse the shared User-Agent while preserving cookie and retry behavior.
- [bot/cogs/BoardGames.py](https://github.com/benjamind10/darkbot/pull/30/files#diff-65329b5bb047d9bd9557a61f55e010b1228914453b12779433548ce81248ad4dR15) - Removed the cog-local API2 literal so command requests follow the shared boardgame utility endpoint.
- [bot/cogs/BoardGames.py](https://github.com/benjamind10/darkbot/pull/30/files#diff-65329b5bb047d9bd9557a61f55e010b1228914453b12779433548ce81248ad4dR79) - Added the shared User-Agent header to BGG search calls without changing query params or embed construction.
- [bot/cogs/BoardGames.py](https://github.com/benjamind10/darkbot/pull/30/files#diff-65329b5bb047d9bd9557a61f55e010b1228914453b12779433548ce81248ad4dR127) - Added the same header to BGG `thing` lookups used by `bginfo`.

### Test Changes

- [tests/test_boardgames.py](https://github.com/benjamind10/darkbot/pull/30/files#diff-96b0034817cd4b7c68ce02faa3d1b2c3a0f7d310111ccf1c28097524486fe165R13) - Imported the shared `BGG_USER_AGENT` constant so tests assert the same value production code uses.
- [tests/test_boardgames.py](https://github.com/benjamind10/darkbot/pull/30/files#diff-96b0034817cd4b7c68ce02faa3d1b2c3a0f7d310111ccf1c28097524486fe165R49) - Confirmed collection fetches still send the User-Agent alongside private collection cookies.
- [tests/test_boardgames.py](https://github.com/benjamind10/darkbot/pull/30/files#diff-96b0034817cd4b7c68ce02faa3d1b2c3a0f7d310111ccf1c28097524486fe165R360) - Confirmed search requests preserve `query` params and include the User-Agent.
- [tests/test_boardgames.py](https://github.com/benjamind10/darkbot/pull/30/files#diff-96b0034817cd4b7c68ce02faa3d1b2c3a0f7d310111ccf1c28097524486fe165R413) - Confirmed game info requests preserve `id`/`stats` params and include the User-Agent.

## Deviations from the plan

No plan file found for this task directory.

### Implemented as planned
- The ticket requested fixing the BGG search `401`; the implementation changes the outbound endpoint and headers that caused that request failure.

### Deviations/surprises
- No formal plan existed, so there were no planned implementation details to deviate from.

### Additions not in plan
- Added coverage for `bginfo` too because it uses the same BGG XML API2 host and should send the same User-Agent as search.
- Added coverage for collection User-Agent behavior to keep the shared constant protected across all BGG HTTP paths.

### Items planned but not implemented
- None.

## How to verify it

### Manual Testing
- [ ] Check out the branch: `git fetch origin fix-bgg-search-api-authentication-error && git switch fix-bgg-search-api-authentication-error`.
- [ ] Install dev dependencies if needed: `pip install -e ".[dev]"`.
- [ ] Run the bot locally with BGG features enabled: `python bot/main.py`.
- [ ] In Discord, run `!bgsearch The King's Dilemma` or `/bgsearch search_query:The King's Dilemma` and confirm results are returned instead of a 401 error.
- [ ] Run `!bginfo 245655` or another valid BGG id and confirm the game info embed still renders.

### Automated Tests
```bash
pytest tests/test_boardgames.py
pyright
```

Note: I attempted `pytest tests/test_boardgames.py` and `python -m pytest tests/test_boardgames.py` in this environment, but `pytest` is not installed here.

## Description for the changelog

Fix BoardGameGeek search authentication failures by using canonical BGG XML endpoints and sending DarkBot's User-Agent on BGG API2 requests.
